### PR TITLE
remove ticks with liquidity_net value equal to 0

### DIFF
--- a/liquidity-sources/src/sources/uniswap_v3/graph_api.rs
+++ b/liquidity-sources/src/sources/uniswap_v3/graph_api.rs
@@ -48,6 +48,7 @@ const POOLS_WITH_TICKS_BY_IDS_QUERY: &str = r#"
             where: {
                 id_in: $ids
                 tick_not: null
+                ticks_: { liquidityNet_not: "0" }
             }
         ) {
             id


### PR DESCRIPTION
Ticks with liquidity_net = 0 are useless.

### Test Plan

Test `uniswap_v3_subgraph_query_get_pools_by_ids` passed.