### PR TITLE
Update data format for solvers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1208,6 +1208,7 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -1217,6 +1218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
 dependencies = [
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -1250,6 +1252,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]

--- a/liquidity-sources/Cargo.toml
+++ b/liquidity-sources/Cargo.toml
@@ -19,7 +19,7 @@ itertools = "0.10"
 lazy_static = "1.4.0"
 lru = "0.7"
 mockall = "0.11"
-num = "0.4"
+num = { version = "0.4", features = ["serde"] }
 once_cell = "1.9.0"
 primitive-types = "0.10"
 prometheus = "0.13"

--- a/liquidity-sources/src/sources/uniswap_v3/graph_api.rs
+++ b/liquidity-sources/src/sources/uniswap_v3/graph_api.rs
@@ -9,7 +9,7 @@ use anyhow::{bail, Result};
 use ethcontract::{H160, U256};
 use num::BigInt;
 use reqwest::Client;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 const ALL_POOLS_QUERY: &str = r#"
@@ -72,6 +72,7 @@ const TICKS_QUERY: &str = r#"
             first: $pageSize
             where: {
                 id_gt: $lastId
+                liquidityNet_not: "0"
             }
         ) {
             id
@@ -200,7 +201,7 @@ impl ContainsId for TickData {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Token {
     pub id: H160,

--- a/liquidity-sources/src/sources/uniswap_v3/pool_fetching.rs
+++ b/liquidity-sources/src/sources/uniswap_v3/pool_fetching.rs
@@ -64,6 +64,7 @@ impl Serialize for TickInfo {
 #[derive(Clone, Debug, Serialize)]
 pub struct PoolStats {
     #[serde(with = "serde_with::rust::display_fromstr")]
+    #[serde(rename = "mean")]
     pub mean_gas: U256,
 }
 
@@ -303,13 +304,17 @@ mod tests {
                     "sqrt_price": "792216481398733702759960397",
                     "liquidity": "303015134493562686441",
                     "tick": "-92110",
-                    "liquidity_net": {
-                        "ticks": [],
-                    },
+                    "liquidity_net":
+                        {
+                            "67260": "5812623076452005012674" ,
+                            "-122070": "104713649338178916454" ,
+                            "-77030": "1182024318125220460617" ,
+                        }
+                    ,
                     "fee": "10000",
                 },
                 "gas_stats": {
-                    "mean_gas": "300000",
+                    "mean": "300000",
                 }
             }),
             serde_json::to_value(PoolInfo {

--- a/liquidity-sources/src/sources/uniswap_v3/pool_fetching.rs
+++ b/liquidity-sources/src/sources/uniswap_v3/pool_fetching.rs
@@ -43,7 +43,7 @@ pub struct PoolState {
 /// Tick data in a format prepared for solvers.
 #[derive(Debug, Clone)]
 pub struct TickInfo {
-    // (tickIdx, liquidity_net)
+    // (tick_idx, liquidity_net)
     ticks: Vec<(BigInt, BigInt)>,
 }
 


### PR DESCRIPTION
Data format for solvers (for UniV3 liquidity) is agreed on with Marco. 
This PR defines this format and does a conversion of UniV3 subgraph data into it.

### Test Plan

Added UTs.
